### PR TITLE
Fix warnings related to premature use of trait bounds in type aliases

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -225,7 +225,7 @@ macro_rules! gen_impl {
             }
 
             /// Array of immutable slices stored on the heap in the same buffer.
-            pub type $slice_name<T: 'static + Copy> = $name<[T]>;
+            pub type $slice_name<T> = $name<[T]>;
 
             /// Array of immutable `str`s stored on the heap in the same buffer.
             pub type $str_name = $name<str>;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -430,8 +430,8 @@ impl<T: ?Sized + StrLike> quickcheck::Arbitrary for Dynamic<T>
     }
 }
 
-/// Ve of immutable slices stored on the heap in the same buffer.
-pub type SliceVec<T: 'static + Copy> = Dynamic<[T]>;
+/// Vec of immutable slices stored on the heap in the same buffer.
+pub type SliceVec<T> = Dynamic<[T]>;
 
 /// Vec of immutable `str`s stored on the heap in the same buffer.
 pub type StringVec = Dynamic<str>;


### PR DESCRIPTION
```
warning[E0122]: trait bounds are not (yet) enforced in type definitions
   --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/multistr-0.5.1/src/vec.rs:434:1
    |
434 | pub type SliceVec<T: 'static + Copy> = Dynamic<[T]>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning[E0122]: trait bounds are not (yet) enforced in type definitions
   --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/multistr-0.5.1/src/array.rs:228:13
    |
228 |               pub type $slice_name<T: 'static + Copy> = $name<[T]>;
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
242 | / gen_impl! {
243 | |     Static2, SliceArray2, StringArray2, CStringArray2, OsStringArray2, 2,
244 | |     Static3, SliceArray3, StringArray3, CStringArray3, OsStringArray3, 3,
245 | |     Static4, SliceArray4, StringArray4, CStringArray4, OsStringArray4, 4,
...   |
257 | |     Static16, SliceArray16, StringArray16, CStringArray16, OsStringArray16, 16,
258 | | }
    | |_- in this macro invocation
```